### PR TITLE
Fix navigation drawer lag

### DIFF
--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MainActivity.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MainActivity.java
@@ -19,6 +19,7 @@ import android.preference.PreferenceManager;
 import android.support.v4.app.Fragment;
 import android.support.v4.content.ContextCompat;
 import android.support.v4.content.LocalBroadcastManager;
+import android.support.v4.widget.DrawerLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.util.DisplayMetrics;
@@ -528,13 +529,44 @@ public class MainActivity extends AppCompatActivity {
                 .show();
     }
 
-    public void goToFragment(Fragment fragment, String tag) {
-        getSupportFragmentManager().beginTransaction()
-                .replace(R.id.content_frame, fragment)
-                .addToBackStack(tag)
-                .commit();
+    public void goToFragment(final Fragment fragment, final String tag) {
+        if (activityDrawer != null && activityDrawer.isDrawerOpen()) {
+            final DrawerLayout drawerLayout = activityDrawer.getDrawerLayout();
+
+            drawerLayout.addDrawerListener(new DrawerLayout.DrawerListener() {
+                @Override
+                public void onDrawerSlide(View drawerView, float slideOffset) {
+
+                }
+
+                @Override
+                public void onDrawerOpened(View drawerView) {
+
+                }
+
+                @Override
+                public void onDrawerClosed(View drawerView) {
+                    replaceWithFragment(fragment, tag);
+
+                    drawerLayout.removeDrawerListener(this);
+                }
+
+                @Override
+                public void onDrawerStateChanged(int newState) {
+
+                }
+            });
+        } else {
+            replaceWithFragment(fragment, tag);
+        }
 
         this.invalidateOptionsMenu();
+    }
+
+    private void replaceWithFragment(Fragment fragment, String tag) {
+        getSupportFragmentManager().beginTransaction()
+                .replace(R.id.content_frame, fragment, tag)
+                .commit();
     }
 
     public void setTitle(String title) {

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/adapter/SponsorAdapter.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/adapter/SponsorAdapter.java
@@ -10,6 +10,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.octo.android.robospice.request.listener.RequestListener;
+import com.squareup.picasso.MemoryPolicy;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
@@ -62,7 +63,11 @@ public class SponsorAdapter extends ArrayAdapter<Sponsor> {
                 imageSize = 300;
                 break;
         }
-        Picasso.with(context).load(item.getImageUrl()).resize(imageSize, imageSize).into(holder.imageSource);
+        Picasso.with(context)
+                .load(item.getImageUrl())
+                .resize(imageSize, imageSize)
+                .memoryPolicy(MemoryPolicy.NO_CACHE, MemoryPolicy.NO_STORE)
+                .into(holder.imageSource);
         holder.tvName.setText(item.getName());
 
         return view;

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HoraireFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HoraireFragment.java
@@ -58,7 +58,6 @@ import ca.etsmtl.applets.etsmobile.util.AnalyticsHelper;
 import ca.etsmtl.applets.etsmobile.util.HoraireManager;
 import ca.etsmtl.applets.etsmobile.util.TrimestreComparator;
 import ca.etsmtl.applets.etsmobile.views.CustomProgressDialog;
-import ca.etsmtl.applets.etsmobile.views.LoadingView;
 import ca.etsmtl.applets.etsmobile2.R;
 
 public class HoraireFragment extends HttpFragment implements Observer, OnDateSelectedListener {
@@ -196,6 +195,8 @@ public class HoraireFragment extends HttpFragment implements Observer, OnDateSel
 
     @Override
     public void onRequestSuccess(final Object o) {
+        super.onRequestSuccess(o);
+
         if (o instanceof ListeDeSessions && !((ListeDeSessions) o).liste.isEmpty()) {
 
             ListeDeSessions listeDeSessions = (ListeDeSessions) o;
@@ -236,7 +237,6 @@ public class HoraireFragment extends HttpFragment implements Observer, OnDateSel
 
         if (isAdded()) {
             fillSeancesList(dateTime.toDate());
-            LoadingView.hideLoadingView(loadingView);
         }
     }
 

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/NotesFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/NotesFragment.java
@@ -7,24 +7,17 @@ import android.view.ViewGroup;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import com.google.android.gms.analytics.HitBuilders;
 import com.octo.android.robospice.persistence.exception.SpiceException;
 
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 
 import ca.etsmtl.applets.etsmobile.ApplicationManager;
-import ca.etsmtl.applets.etsmobile.http.DataManager;
 import ca.etsmtl.applets.etsmobile.http.DataManager.SignetMethods;
-import ca.etsmtl.applets.etsmobile.model.Cours;
 import ca.etsmtl.applets.etsmobile.model.ListeDeCours;
 import ca.etsmtl.applets.etsmobile.model.ListeDeSessions;
-import ca.etsmtl.applets.etsmobile.model.Trimestre;
-import ca.etsmtl.applets.etsmobile.ui.activity.MainActivity;
 import ca.etsmtl.applets.etsmobile.ui.adapter.NoteAdapter;
 import ca.etsmtl.applets.etsmobile.ui.adapter.NotesSessionItem;
 import ca.etsmtl.applets.etsmobile.ui.adapter.SessionCoteAdapter;
@@ -76,7 +69,8 @@ public class NotesFragment extends HttpFragment implements Observer {
         mapNoteACeJour = new HashMap<>();
         loadingView.showLoadingView();
 
-        refreshList();
+        if (isAdded())
+            refreshList();
 
         dataManager.getDataFromSignet(SignetMethods.LIST_COURS, ApplicationManager.userCredentials, this, "");
         dataManager.getDataFromSignet(SignetMethods.LIST_SESSION, ApplicationManager.userCredentials, this, "");
@@ -139,15 +133,17 @@ public class NotesFragment extends HttpFragment implements Observer {
             notesSession = new NotesSessionItem[listeDeSessions.liste.size()];
             genererSessionCote(mapSession);
 
-            getActivity().runOnUiThread(new Runnable() {
+            if (getActivity() != null) {
+                getActivity().runOnUiThread(new Runnable() {
 
-                @Override
-                public void run() {
-                    adapter = new NoteAdapter(getActivity(), R.layout.row_note_menu, notesSession);
-                    mListView.setAdapter(adapter);
-                }
+                    @Override
+                    public void run() {
+                        adapter = new NoteAdapter(getActivity(), R.layout.row_note_menu, notesSession);
+                        mListView.setAdapter(adapter);
+                    }
 
-            });
+                });
+            }
         }
 
     }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/TodayFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/TodayFragment.java
@@ -130,12 +130,12 @@ public class TodayFragment extends HttpFragment implements Observer {
     public void onRequestSuccess(Object o) {
 
         if (isAdded()) {
-            if (o instanceof ListeDeSessions) {
+            if (o instanceof ListeDeSessions && ((ListeDeSessions) o).liste.size() > 0) {
 
                 ListeDeSessions listeDeSessions = (ListeDeSessions) o;
                 Date currentDate = new Date();
-                Date dateStart;
-                Date dateEnd;
+                Date dateStart = new Date();
+                Date dateEnd = new Date();
 
                 Collections.sort(listeDeSessions.liste, new Comparator<Trimestre>() {
                     @Override
@@ -147,13 +147,17 @@ public class TodayFragment extends HttpFragment implements Observer {
                     }
                 });
 
+                Trimestre trimestre = null;
+
                 // Obtention de la session précédente
-                Trimestre trimestre = listeDeSessions.liste.get(1);
-                dateStart = Utility.getDateFromString(trimestre.dateDebut);
-                dateEnd = Utility.getDateFromString(trimestre.dateFin);
+                if (listeDeSessions.liste.size() > 1) {
+                    trimestre = listeDeSessions.liste.get(1);
+                    dateStart = Utility.getDateFromString(trimestre.dateDebut);
+                    dateEnd = Utility.getDateFromString(trimestre.dateFin);
+                }
 
                 // Si la session précédente est cours...
-                if (isAdded() && currentDate.after(dateStart) && currentDate.before(dateEnd)) {
+                if (isAdded() && trimestre != null && currentDate.after(dateStart) && currentDate.before(dateEnd)) {
                     saveSemesterProgressBarDatesToPrefs(trimestre.dateDebut, trimestre.dateFin);
                     setSemesterProgressBarText(dateStart, dateEnd);
                 } else {

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/TodayFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/TodayFragment.java
@@ -129,43 +129,45 @@ public class TodayFragment extends HttpFragment implements Observer {
     @Override
     public void onRequestSuccess(Object o) {
 
-        if (o instanceof ListeDeSessions) {
+        if (isAdded()) {
+            if (o instanceof ListeDeSessions) {
 
-            ListeDeSessions listeDeSessions = (ListeDeSessions) o;
-            Date currentDate = new Date();
-            Date dateStart;
-            Date dateEnd;
+                ListeDeSessions listeDeSessions = (ListeDeSessions) o;
+                Date currentDate = new Date();
+                Date dateStart;
+                Date dateEnd;
 
-            Collections.sort(listeDeSessions.liste, new Comparator<Trimestre>() {
-                @Override
-                public int compare(Trimestre t1, Trimestre t2) {
-                    Date dateT1 = Utility.getDateFromString(t1.dateDebut);
-                    Date dateT2 = Utility.getDateFromString(t2.dateDebut);
+                Collections.sort(listeDeSessions.liste, new Comparator<Trimestre>() {
+                    @Override
+                    public int compare(Trimestre t1, Trimestre t2) {
+                        Date dateT1 = Utility.getDateFromString(t1.dateDebut);
+                        Date dateT2 = Utility.getDateFromString(t2.dateDebut);
 
-                    return dateT2.compareTo(dateT1);
-                }
-            });
+                        return dateT2.compareTo(dateT1);
+                    }
+                });
 
-            // Obtention de la session précédente
-            Trimestre trimestre = listeDeSessions.liste.get(1);
-            dateStart = Utility.getDateFromString(trimestre.dateDebut);
-            dateEnd = Utility.getDateFromString(trimestre.dateFin);
-
-            // Si la session précédente est cours...
-            if (isAdded() && currentDate.after(dateStart) && currentDate.before(dateEnd)) {
-                saveSemesterProgressBarDatesToPrefs(trimestre.dateDebut, trimestre.dateFin);
-                setSemesterProgressBarText(dateStart, dateEnd);
-            } else {
-                trimestre = listeDeSessions.liste.get(0);
-
+                // Obtention de la session précédente
+                Trimestre trimestre = listeDeSessions.liste.get(1);
                 dateStart = Utility.getDateFromString(trimestre.dateDebut);
                 dateEnd = Utility.getDateFromString(trimestre.dateFin);
 
-                saveSemesterProgressBarDatesToPrefs(trimestre.dateDebut, trimestre.dateFin);
-                setSemesterProgressBarText(dateStart, dateEnd);
+                // Si la session précédente est cours...
+                if (isAdded() && currentDate.after(dateStart) && currentDate.before(dateEnd)) {
+                    saveSemesterProgressBarDatesToPrefs(trimestre.dateDebut, trimestre.dateFin);
+                    setSemesterProgressBarText(dateStart, dateEnd);
+                } else {
+                    trimestre = listeDeSessions.liste.get(0);
+
+                    dateStart = Utility.getDateFromString(trimestre.dateDebut);
+                    dateEnd = Utility.getDateFromString(trimestre.dateFin);
+
+                    saveSemesterProgressBarDatesToPrefs(trimestre.dateDebut, trimestre.dateFin);
+                    setSemesterProgressBarText(dateStart, dateEnd);
+                }
+            } else {
+                horaireManager.onRequestSuccess(o);
             }
-        } else {
-            horaireManager.onRequestSuccess(o);
         }
     }
 

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/views/LoadingView.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/views/LoadingView.java
@@ -1,6 +1,8 @@
 package ca.etsmtl.applets.etsmobile.views;
 
 import android.content.Context;
+import android.graphics.PorterDuff;
+import android.support.v4.content.ContextCompat;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -40,6 +42,7 @@ public class LoadingView extends RelativeLayout {
     public void init(Context context){
         LayoutInflater.from(context).inflate(R.layout.base_layout, this, true);
         progressBar = (ProgressBar) findViewById(R.id.base_layout_loading_pb);
+        progressBar.getIndeterminateDrawable().setColorFilter(ContextCompat.getColor(context, R.color.ets_red), PorterDuff.Mode.SRC_IN);
         textView = (TextView) findViewById(R.id.base_layout_error_tv);
         textView.setVisibility(View.GONE);
     }

--- a/app/src/main/res/layout/calendar_horaire_layout.xml
+++ b/app/src/main/res/layout/calendar_horaire_layout.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
     <ViewSwitcher
         android:id="@+id/horraireViewSwitcher"
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        tools:visibility="visible">
 
         <ListView
             android:id="@+id/calendar_listview"
@@ -18,8 +20,8 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:layout_margin="10dp">
+            android:layout_margin="10dp"
+            android:orientation="vertical">
 
             <com.prolificinteractive.materialcalendarview.MaterialCalendarView
                 android:id="@+id/calendarView"
@@ -122,17 +124,10 @@
                 </LinearLayout>
             </LinearLayout>
         </LinearLayout>
-
-
     </ViewSwitcher>
 
-    <ProgressBar
-        android:id="@+id/progressBar_sync_horaire"
-        style="?android:attr/progressBarStyleSmall"
+    <ca.etsmtl.applets.etsmobile.views.LoadingView
+        android:id="@+id/loadingView"
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentRight="true"
-        android:layout_alignParentTop="true"
-        android:layout_marginRight="20px"
-        android:layout_marginTop="20px" />
-</LinearLayout>
+        android:layout_height="wrap_content" />
+</RelativeLayout>


### PR DESCRIPTION
Fix #51

-Ajout d'un écouteur afin d'effectuer le remplacement du fragment après la fermeture du menu
-Utilisation d'un Runnable et d'un Handler afin de réduire le ralentissement lors
du chargement de HoraireFragment
-Affichage du roue de chargement de HoraireFragment
-Changement de couleur du roue de chargement 