### PR TITLE
Fix some crashes

### DIFF
--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MainActivity.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MainActivity.java
@@ -531,7 +531,6 @@ public class MainActivity extends AppCompatActivity {
     public void goToFragment(Fragment fragment, String tag) {
         getSupportFragmentManager().beginTransaction()
                 .replace(R.id.content_frame, fragment)
-                .addToBackStack(tag)
                 .commit();
 
         this.invalidateOptionsMenu();

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/BottinFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/BottinFragment.java
@@ -256,7 +256,7 @@ public class BottinFragment extends BaseFragment implements SearchView.OnQueryTe
                 afficherRafraichissementEtRechargerBottin();
             }
         } catch (Exception e) {
-            Log.e("BD FicheEmploye", e.getMessage());
+            Log.e("BD FicheEmploye", "" + e.getMessage());
         }
     }
 

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HoraireFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HoraireFragment.java
@@ -393,6 +393,13 @@ public class HoraireFragment extends HttpFragment implements Observer, OnDateSel
         builder.show();
     }
 
+    @Override
+    public void onDetach() {
+        super.onDetach();
+
+        horaireManager.deleteObserver(this);
+    }
+
     private class AsyncUpdateCalendar extends AsyncTask<Object, Void, Object> {
 
         /**

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HoraireFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HoraireFragment.java
@@ -49,7 +49,6 @@ import ca.etsmtl.applets.etsmobile.model.Event;
 import ca.etsmtl.applets.etsmobile.model.ListeDeSessions;
 import ca.etsmtl.applets.etsmobile.model.Seances;
 import ca.etsmtl.applets.etsmobile.model.Trimestre;
-import ca.etsmtl.applets.etsmobile.ui.activity.MainActivity;
 import ca.etsmtl.applets.etsmobile.ui.adapter.SeanceAdapter;
 import ca.etsmtl.applets.etsmobile.ui.calendar_decorator.CourseDecorator;
 import ca.etsmtl.applets.etsmobile.ui.calendar_decorator.CourseTodayDecorator;
@@ -270,6 +269,9 @@ public class HoraireFragment extends HttpFragment implements Observer, OnDateSel
         upcomingseanceAdapter.notifyDataSetChanged();
     }
     public void fillSeancesList(Date date) {
+        if (getActivity() == null || !isAdded())
+            return;
+
         SimpleDateFormat seancesFormatter = new SimpleDateFormat("yyyy-MM-dd", getResources().getConfiguration().locale);
         String today = seancesFormatter.format(date).toString();
 

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HttpFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/HttpFragment.java
@@ -68,4 +68,11 @@ public abstract class HttpFragment extends BaseFragment implements RequestListen
             });
 		}
 	}
+
+	@Override
+	public void onDetach() {
+		super.onDetach();
+
+		dataManager.stop();
+	}
 }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/NotesFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/NotesFragment.java
@@ -7,24 +7,17 @@ import android.view.ViewGroup;
 import android.widget.ListView;
 import android.widget.Toast;
 
-import com.google.android.gms.analytics.HitBuilders;
 import com.octo.android.robospice.persistence.exception.SpiceException;
 
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 
 import ca.etsmtl.applets.etsmobile.ApplicationManager;
-import ca.etsmtl.applets.etsmobile.http.DataManager;
 import ca.etsmtl.applets.etsmobile.http.DataManager.SignetMethods;
-import ca.etsmtl.applets.etsmobile.model.Cours;
 import ca.etsmtl.applets.etsmobile.model.ListeDeCours;
 import ca.etsmtl.applets.etsmobile.model.ListeDeSessions;
-import ca.etsmtl.applets.etsmobile.model.Trimestre;
-import ca.etsmtl.applets.etsmobile.ui.activity.MainActivity;
 import ca.etsmtl.applets.etsmobile.ui.adapter.NoteAdapter;
 import ca.etsmtl.applets.etsmobile.ui.adapter.NotesSessionItem;
 import ca.etsmtl.applets.etsmobile.ui.adapter.SessionCoteAdapter;
@@ -138,6 +131,9 @@ public class NotesFragment extends HttpFragment implements Observer {
             regrouperCoursParSession(mapSession);
             notesSession = new NotesSessionItem[listeDeSessions.liste.size()];
             genererSessionCote(mapSession);
+
+            if (getActivity() == null || !isAdded())
+                return;
 
             getActivity().runOnUiThread(new Runnable() {
 

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/NotesFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/NotesFragment.java
@@ -208,4 +208,11 @@ public class NotesFragment extends HttpFragment implements Observer {
                 refreshList();
             }
     }
+
+    @Override
+    public void onDetach() {
+        super.onDetach();
+
+        mNoteManager.deleteObserver(this);
+    }
 }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/TodayFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/TodayFragment.java
@@ -209,6 +209,9 @@ public class TodayFragment extends HttpFragment implements Observer {
             progressionMs = dateActuelle.getTime() - dateDebut.getTime();
             progressionJour = TimeUnit.MILLISECONDS.toDays(progressionMs);
 
+            if (getActivity() == null || !isAdded())
+                return;
+
             semesterProgressBar.setMax((int) nbJoursTotal);
             semesterProgressBar.setProgress((int) progressionJour);
             semesterProgressBarText.setText(getString(R.string.semester_progression)


### PR DESCRIPTION
Dans Fabric, les crashes les plus fréquents surviennent lorsque le fragment n'est plus attachée. Lors de l'exécution d'une tâche par DataManager, celui-ci garde une référence du fragment, car celui-ci est l'écouteur. Lors du callback, il est possible que le fragment ne soit plus attachée à l'activité. L'utilisateur pourrait avoir changé de fragment pendant l'exécution de la tâche. Par conséquent, l'écouteur (le fragment) doit être retiré lors du détachement.