### PR TITLE
 Store assignments submissions in db

### DIFF
--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/db/MoodleAssignmentSubmissionDao.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/db/MoodleAssignmentSubmissionDao.java
@@ -1,0 +1,21 @@
+package ca.etsmtl.applets.etsmobile.db;
+
+import android.arch.lifecycle.LiveData;
+import android.arch.persistence.room.Dao;
+import android.arch.persistence.room.Insert;
+import android.arch.persistence.room.OnConflictStrategy;
+import android.arch.persistence.room.Query;
+
+import ca.etsmtl.applets.etsmobile.model.Moodle.MoodleAssignmentSubmission;
+
+/**
+ * Created by Sonphil on 31-12-17.
+ */
+@Dao
+public interface MoodleAssignmentSubmissionDao {
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(MoodleAssignmentSubmission moodleAssignmentSubmission);
+
+    @Query("SELECT * FROM moodleassignmentsubmission WHERE assignId = :assignmentId LIMIT 1")
+    LiveData<MoodleAssignmentSubmission> getByAssignmentId(int assignmentId);
+}

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/db/MoodleDb.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/db/MoodleDb.java
@@ -4,13 +4,15 @@ import android.arch.persistence.room.Database;
 import android.arch.persistence.room.RoomDatabase;
 
 import ca.etsmtl.applets.etsmobile.model.Moodle.MoodleAssignmentCourse;
+import ca.etsmtl.applets.etsmobile.model.Moodle.MoodleAssignmentSubmission;
 import ca.etsmtl.applets.etsmobile.model.Moodle.MoodleCourse;
 import ca.etsmtl.applets.etsmobile.model.Moodle.MoodleProfile;
 
 /**
  * Created by Sonphil on 26-12-17.
  */
-@Database(entities = {MoodleProfile.class, MoodleCourse.class, MoodleAssignmentCourse.class}, version = 1)
+@Database(entities = {MoodleProfile.class, MoodleCourse.class, MoodleAssignmentCourse.class,
+        MoodleAssignmentSubmission.class}, version = 1)
 public abstract class MoodleDb extends RoomDatabase {
 
     public abstract MoodleProfileDao moodleProfileDao();
@@ -18,4 +20,6 @@ public abstract class MoodleDb extends RoomDatabase {
     public abstract MoodleCourseDao moodleCourseDao();
 
     public abstract MoodleAssignmentCourseDao moodleAssignmentCourseDao();
+
+    public abstract MoodleAssignmentSubmissionDao moodleAssignmentSubmissionDao();
 }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/di/AppModule.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/di/AppModule.java
@@ -3,11 +3,10 @@ package ca.etsmtl.applets.etsmobile.di;
 import android.app.Application;
 import android.arch.persistence.room.Room;
 
-import java.util.concurrent.Executor;
-
 import javax.inject.Singleton;
 
 import ca.etsmtl.applets.etsmobile.db.MoodleAssignmentCourseDao;
+import ca.etsmtl.applets.etsmobile.db.MoodleAssignmentSubmissionDao;
 import ca.etsmtl.applets.etsmobile.db.MoodleCourseDao;
 import ca.etsmtl.applets.etsmobile.db.MoodleDb;
 import ca.etsmtl.applets.etsmobile.db.MoodleProfileDao;
@@ -81,7 +80,7 @@ public class AppModule {
 
     @Provides
     @Singleton
-    Executor provideExecutor() {
-        return runnable -> new Thread(runnable).start();
+    MoodleAssignmentSubmissionDao provideMoodleAssignmentSubmissionDao(MoodleDb moodleDb) {
+        return moodleDb.moodleAssignmentSubmissionDao();
     }
 }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/model/Moodle/MoodleAssignmentSubmission.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/model/Moodle/MoodleAssignmentSubmission.java
@@ -1,6 +1,15 @@
 package ca.etsmtl.applets.etsmobile.model.Moodle;
 
+import android.arch.persistence.room.Entity;
+import android.arch.persistence.room.PrimaryKey;
+import android.arch.persistence.room.TypeConverter;
+import android.arch.persistence.room.TypeConverters;
+
+import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+
+import java.lang.reflect.Type;
 
 /**
  * Submission of an assignment
@@ -12,17 +21,67 @@ import com.google.gson.annotations.SerializedName;
  * <p>
  * Created by Sonphil on 02-09-17.
  */
+@Entity
+@TypeConverters(MoodleAssignmentSubmission.Covnerters.class)
 public class MoodleAssignmentSubmission {
+    @PrimaryKey
+    private int assignId;
     @SerializedName("lastattempt")
     private MoodleAssignmentLastAttempt lastAttempt;
     @SerializedName("feedback")
     private MoodleAssignmentFeedback feedback;
 
+    public int getAssignId() {
+        return assignId;
+    }
+
+    public void setAssignId(int assignId) {
+        this.assignId = assignId;
+    }
+
     public MoodleAssignmentLastAttempt getLastAttempt() {
         return lastAttempt;
     }
 
+    public void setLastAttempt(MoodleAssignmentLastAttempt lastAttempt) {
+        this.lastAttempt = lastAttempt;
+    }
+
     public MoodleAssignmentFeedback getFeedback() {
         return feedback;
+    }
+
+    public void setFeedback(MoodleAssignmentFeedback feedback) {
+        this.feedback = feedback;
+    }
+
+    public static final class Covnerters {
+        @TypeConverter
+        public static MoodleAssignmentLastAttempt stringToLastAttempt(String json) {
+            Gson gson = new Gson();
+            Type type = new TypeToken<MoodleAssignmentLastAttempt>() {}.getType();
+            return gson.fromJson(json, type);
+        }
+
+        @TypeConverter
+        public static String lastAttemptToString(MoodleAssignmentLastAttempt lastAttempt) {
+            Gson gson = new Gson();
+            Type type = new TypeToken<MoodleAssignmentLastAttempt>() {}.getType();
+            return gson.toJson(lastAttempt, type);
+        }
+
+        @TypeConverter
+        public static MoodleAssignmentFeedback stringToFeedback(String json) {
+            Gson gson = new Gson();
+            Type type = new TypeToken<MoodleAssignmentFeedback>() {}.getType();
+            return gson.fromJson(json, type);
+        }
+
+        @TypeConverter
+        public static String feedbackToString(MoodleAssignmentFeedback feedback) {
+            Gson gson = new Gson();
+            Type type = new TypeToken<MoodleAssignmentFeedback>() {}.getType();
+            return gson.toJson(feedback, type);
+        }
     }
 }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MoodleAssignmentsActivity.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MoodleAssignmentsActivity.java
@@ -138,9 +138,7 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
                 } else if (listRemoteResource.status == RemoteResource.ERROR) {
                     requestInProgress = false;
                     loadingView.hideProgessBar();
-                    Toast t = Toast.makeText(this, getString(R.string.toast_Sync_Fail)
-                            + "\n" + listRemoteResource.message, Toast.LENGTH_LONG);
-                    t.show();
+                    displayErrorMessage(getString(R.string.toast_Sync_Fail));
                 } else if (listRemoteResource.status == RemoteResource.LOADING) {
                     requestInProgress = true;
                     if (listRemoteResource.data != null) {
@@ -319,9 +317,8 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
                     if (noDataToDsiplay)
                         bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
 
-                    String errorMsg = moodleAssignmentSubmission == null ? getString(R.string.error_JSON_PARSING) : moodleAssignmentSubmission.message;
-                    Toast toast = Toast.makeText(MoodleAssignmentsActivity.this, errorMsg, Toast.LENGTH_SHORT);
-                    toast.show();
+                    String errorMsg = getString(R.string.toast_Sync_Fail);
+                    displayErrorMessage(errorMsg);
                 } else if (moodleAssignmentSubmission.status == RemoteResource.SUCCESS) {
                     MoodleAssignmentSubmission submission = moodleAssignmentSubmission.data;
 
@@ -346,6 +343,11 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
                     submissionLiveData.removeObserver(this);
             }
         });
+    }
+
+    private void displayErrorMessage(String errorMsg) {
+        Toast toast = Toast.makeText(this, errorMsg, Toast.LENGTH_SHORT);
+        toast.show();
     }
 
     public void openInBrowser(View v) {

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MoodleAssignmentsActivity.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MoodleAssignmentsActivity.java
@@ -297,6 +297,7 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
 
     private void displaySelectedAssignment(final MoodleAssignment selectedAssignment) {
         binding.setSelectedAssignment(selectedAssignment);
+        bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
 
         final LiveData<RemoteResource<MoodleAssignmentSubmission>> submissionLiveData = moodleViewModel.getAssignmentSubmission(selectedAssignment.getId());
         submissionLiveData.observe(MoodleAssignmentsActivity.this, new Observer<RemoteResource<MoodleAssignmentSubmission>>() {
@@ -314,7 +315,8 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
 
                     bottomSheet.requestLayout();
 
-                    if (moodleAssignmentSubmission == null || moodleAssignmentSubmission.data == null && bottomSheetBehavior.getState() != BottomSheetBehavior.STATE_EXPANDED)
+                    boolean noDataToDsiplay = moodleAssignmentSubmission == null || moodleAssignmentSubmission.data == null;
+                    if (noDataToDsiplay)
                         bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
 
                     String errorMsg = moodleAssignmentSubmission == null ? getString(R.string.error_JSON_PARSING) : moodleAssignmentSubmission.message;
@@ -336,10 +338,8 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
                     binding.setLoadingSelectedAssignmentSubmission(true);
                     noLongerNeedtoObserve = false;
 
-                    if (bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN) {
-                        bottomSheet.requestLayout();
-                        bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
-                    }
+                    bottomSheet.requestLayout();
+                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
                 }
 
                 if (noLongerNeedtoObserve)

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MoodleAssignmentsActivity.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/activity/MoodleAssignmentsActivity.java
@@ -301,22 +301,27 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
         final LiveData<RemoteResource<MoodleAssignmentSubmission>> submissionLiveData = moodleViewModel.getAssignmentSubmission(selectedAssignment.getId());
         submissionLiveData.observe(MoodleAssignmentsActivity.this, new Observer<RemoteResource<MoodleAssignmentSubmission>>() {
             @Override
-            public void onChanged(@Nullable RemoteResource<MoodleAssignmentSubmission> moodleAssignmentFeedbackRemoteResource) {
+            public void onChanged(@Nullable RemoteResource<MoodleAssignmentSubmission> moodleAssignmentSubmission) {
                 boolean noLongerNeedtoObserve = true;
 
-                if (moodleAssignmentFeedbackRemoteResource == null || moodleAssignmentFeedbackRemoteResource.status == RemoteResource.ERROR) {
-                    binding.setSelectedAssignmentFeedback(null);
-                    binding.setSelectedAssignmentLastAttempt(null);
+                if (moodleAssignmentSubmission == null || moodleAssignmentSubmission.status == RemoteResource.ERROR) {
+                    if (moodleAssignmentSubmission != null && moodleAssignmentSubmission.data != null) {
+                        binding.setSelectedAssignmentFeedback(moodleAssignmentSubmission.data.getFeedback());
+                        binding.setSelectedAssignmentLastAttempt(moodleAssignmentSubmission.data.getLastAttempt());
+                    }
+
                     binding.setLoadingSelectedAssignmentSubmission(false);
 
                     bottomSheet.requestLayout();
-                    bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
 
-                    String errorMsg = moodleAssignmentFeedbackRemoteResource == null ? getString(R.string.error_JSON_PARSING) : moodleAssignmentFeedbackRemoteResource.message;
+                    if (moodleAssignmentSubmission == null || moodleAssignmentSubmission.data == null && bottomSheetBehavior.getState() != BottomSheetBehavior.STATE_EXPANDED)
+                        bottomSheetBehavior.setState(BottomSheetBehavior.STATE_HIDDEN);
+
+                    String errorMsg = moodleAssignmentSubmission == null ? getString(R.string.error_JSON_PARSING) : moodleAssignmentSubmission.message;
                     Toast toast = Toast.makeText(MoodleAssignmentsActivity.this, errorMsg, Toast.LENGTH_SHORT);
                     toast.show();
-                } else if (moodleAssignmentFeedbackRemoteResource.status == RemoteResource.SUCCESS) {
-                    MoodleAssignmentSubmission submission = moodleAssignmentFeedbackRemoteResource.data;
+                } else if (moodleAssignmentSubmission.status == RemoteResource.SUCCESS) {
+                    MoodleAssignmentSubmission submission = moodleAssignmentSubmission.data;
 
                     if (submission != null) {
                         binding.setSelectedAssignmentFeedback(submission.getFeedback());
@@ -327,12 +332,11 @@ public class MoodleAssignmentsActivity extends AppCompatActivity {
                     }
 
                     binding.setLoadingSelectedAssignmentSubmission(false);
-                } else if (moodleAssignmentFeedbackRemoteResource.status == RemoteResource.LOADING) {
+                } else if (moodleAssignmentSubmission.status == RemoteResource.LOADING) {
                     binding.setLoadingSelectedAssignmentSubmission(true);
                     noLongerNeedtoObserve = false;
 
-                    if (bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN
-                            && Utility.isNetworkAvailable(MoodleAssignmentsActivity.this)) {
+                    if (bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_HIDDEN) {
                         bottomSheet.requestLayout();
                         bottomSheetBehavior.setState(BottomSheetBehavior.STATE_EXPANDED);
                     }

--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/MoodleFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/MoodleFragment.java
@@ -105,8 +105,7 @@ public class MoodleFragment extends BaseFragment {
                     } else if (moodleCoursesRemoteResource.status == RemoteResource.ERROR) {
                         loadingView.hideProgessBar();
                         if (loadingView.isShown()) {
-                            String errorMsg = getString(R.string.toast_Sync_Fail)
-                                    + "\n" + moodleCoursesRemoteResource.message;
+                            String errorMsg = getString(R.string.toast_Sync_Fail);
                             Toast t = Toast.makeText(getContext(), errorMsg, Toast.LENGTH_LONG);
                             t.show();;
                         }


### PR DESCRIPTION
Les soumissions de devoirs sont, désormais, sauvegardés dans la BD . Si l'appareil de l'utilisateur est déconnecté, il pourra tout de même afficher un devoir si la soumission de celui-ci a été sauvegardée dans la BD antérieurement.
#114 
![device-2017-12-31-220838](https://user-images.githubusercontent.com/22182973/34465408-3e5507b4-ee79-11e7-9f35-a6d6104fd30c.gif)