### PR TITLE
Change runtime permissions

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,22 +24,17 @@
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="ca.etsmtl.applets.etsmobile.permission.C2D_MESSAGE" />
+    <uses-permission android:name="android.permission.WAKE_LOCK" />
 
     <permission
         android:name="ca.etsmtl.applets.etsmobile.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
 
-    <uses-permission android:name="ca.etsmtl.applets.etsmobile.permission.C2D_MESSAGE" />
-    <uses-permission android:name="android.permission.WAKE_LOCK" />
-
     <uses-feature
         android:glEsVersion="0x00020000"
         android:required="true" />
-
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
-    <uses-permission android:name="android.permission.READ_CALL_LOG" />
-    <uses-permission android:name="android.permission.WRITE_CALL_LOG" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <application
         android:name="ca.etsmtl.applets.etsmobile.ApplicationManager"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,10 +32,6 @@
         android:name="ca.etsmtl.applets.etsmobile.permission.C2D_MESSAGE"
         android:protectionLevel="signature" />
 
-    <uses-feature
-        android:glEsVersion="0x00020000"
-        android:required="true" />
-
     <application
         android:name="ca.etsmtl.applets.etsmobile.ApplicationManager"
         android:allowBackup="true"


### PR DESCRIPTION
Depuis novembre 2018, Google a restreint l'utilisation des permissions concernant l'utilisation des SMS et des journaux d'appels. Plus d'informations disponibles ci-dessous:

https://support.google.com/googleplay/android-developer/answer/9047303

Si l'application n'est pas conforme d'ici le 8 janvier 2019, celle-ci pourrait se retrouver retirée du Play Store.