### PR TITLE
Save correctly a room's phase when checking bandwidth

### DIFF
--- a/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/BandwidthFragment.java
+++ b/app/src/main/java/ca/etsmtl/applets/etsmobile/ui/fragment/BandwidthFragment.java
@@ -117,7 +117,7 @@ public class BandwidthFragment extends BaseFragment {
 
         if (phase.length() > 0 && app.length() > 0) {
             editTextApp.setText(app);
-            editTextPhase.setText(phase);
+            phaseSpinner.setSelection(Integer.parseInt(phase) - 1);
             getBandwidth(phase, app, chambre);
         }
 


### PR DESCRIPTION
Situation issue d'un étudiant qui n'arrivait à obtenir totalement l'information concernant la bande passante de son appartement dû à la phase qui n'était pas totalement sauvegardée lors de la recherche initiale de celle-ci.