### PR TITLE
Fix crash when going on Moodle Assignments

### DIFF
--- a/app/src/main/res/layout/activity_moodle_assignments.xml
+++ b/app/src/main/res/layout/activity_moodle_assignments.xml
@@ -109,7 +109,7 @@
             android:orientation="vertical"
             android:paddingTop="@dimen/fab_margin"
             app:behavior_hideable="true"
-            app:layout_behavior="android.support.design.widget.BottomSheetBehavior">
+            app:layout_behavior="com.google.android.material.bottomsheet.BottomSheetBehavior">
 
             <!-- Titre -->
             <TextView


### PR DESCRIPTION
L'accès aux travaux sur Moodle ne fonctionnait pas dû à des changements lors de la migration vers AndroidX. L'outil de migration n'a pas pris en compte certains chemins changés ce qui causait des fermetures non souhaitées.