### PR TITLE
Fix crash on Android 4.x devices for GCM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -127,7 +127,7 @@ dependencies {
     implementation 'com.j256.ormlite:ormlite-android:4.48'
     implementation 'com.github.markushi:circlebutton:1.1'
     implementation 'com.flaviofaria:kenburnsview:1.0.7'
-    implementation 'com.evernote:android-job:1.2.0'
+    implementation 'com.evernote:android-job:1.2.6'
     implementation 'com.getkeepsafe.taptargetview:taptargetview:1.9.1'
     implementation 'io.reactivex.rxjava2:rxandroid:2.0.1'
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="ca.etsmtl.applets.etsmobile2">
 
     <uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS" />
@@ -216,6 +217,11 @@
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/provider_paths"/>
         </provider>
+
+        <service
+            android:name="com.evernote.android.job.gcm.PlatformGcmService"
+            android:enabled="true"
+            tools:replace="android:enabled"/>
     </application>
 
 </manifest>


### PR DESCRIPTION
Since GCM is used for notifications, there was a problem using it
alongside Evernote's job library. Update the library version and add the
service accordingly based on the following:

https://github.com/evernote/android-job#google-play-services